### PR TITLE
Fix Swagger validation error due to missing description

### DIFF
--- a/rest_api_demo/api/restplus.py
+++ b/rest_api_demo/api/restplus.py
@@ -22,5 +22,6 @@ def default_error_handler(e):
 
 @api.errorhandler(NoResultFound)
 def database_not_found_error_handler(e):
+    'No results found in database'
     log.warning(traceback.format_exc())
     return {'message': 'A database result was required but none was found.'}, 404


### PR DESCRIPTION
Fixes one Swagger validation error in https://github.com/postrational/rest_api_demo/issues/3

Error:
```python
In [1]: import swagger_spec_validator
In [2]: swagger_spec_validator.validate_spec_url('http://localhost:8888/api/swagger.json')
#Exception...
SwaggerValidationError: 'description' is a required property
...
On instance['responses']['NoResultFound']:
```

With patch applied:
```diff
$ diff -Naur swagger.orig.yaml swagger.yaml
@@ -379,7 +379,8 @@
 responses:
   MaskError:
     description: When any error occurs on mask
-  NoResultFound: {}
+  NoResultFound:
+    description: No results found in database
   ParseError:
     description: When a mask can't be parsed
 swagger: '2.0'
```

validation passes OK
```python
In [1]: import swagger_spec_validator
In [2]: swagger_spec_validator.validate_spec_url('http://localhost:8888/api/swagger.json')
In [3]: from bravado.client import SwaggerClient
In [4]: client = SwaggerClient.from_url('http://localhost:8888/api/swagger.json')
In [5]:
```